### PR TITLE
Code Overhaul

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,9 +1,9 @@
 === Drafts Dropdown ===
-Contributors: alexkingorg, crowdfavorite
+Contributors: alexkingorg, crowdfavorite, syberspace
 Tags: draft, drafts, post, admin, access, shortcut
-Requires at least: 3.2
-Tested up to: 3.2.1
-Stable tag: 2.0.2
+Requires at least: 3.8
+Tested up to: 3.9.1
+Stable tag: 3.0.0
 
 Adds a Drafts tab to the admin bar so that you can quickly access your draft blog posts.
 
@@ -23,7 +23,7 @@ Wish you had quicker access to your draft posts and pages? Tired of having to cl
 
 Yes.
 
-= Does this work on versions of WordPress prior to 3.2? =
+= Does this work on versions of WordPress prior to 3.8? =
 
 Perhaps - however it has not been tested.
 
@@ -33,6 +33,12 @@ Perhaps - however it has not been tested.
 2. Here are the draft posts - w00T!
 
 == Changelog ==
+= 3.0.0=
+* Complete code overhaul
+* AJAX overhaul ( now does only send metadata, not full html )
+* Fixed slideDown followed by slideUp ( now only does slideDown )
+* Restyled Columns ( number of columns can now be adjusted in css file )
+* Moved script and style to seperate files ( allows for caching with plugins like W3 Total Cache)
 
 = 2.0.2 =
 * Enable drawer on post add/edit screen.

--- a/css/drafts-dropdown.css
+++ b/css/drafts-dropdown.css
@@ -1,0 +1,60 @@
+#wp-admin-bar-cfdd_drafts_menu.loading {
+	cursor: wait !important;
+}
+#wp-admin-bar-cfdd_drafts_menu.loading:before{ /* Firefox Compatibility */
+	position: absolute;
+	content: '\200B';
+	width: 100%;
+	top: 0;
+	left: 0;
+	text-align:center;
+}
+
+#cfdd_drafts_wrap {
+	background: #444;
+	border-top: 1px solid #999;
+	border-bottom: 5px solid #666;
+	-webkit-box-shadow: 0px 2px 2px rgba(0,0,0,0.8), inset 0px 0px 4px rgba(0,0,0,0.5);
+	box-shadow: 0px 2px 4px rgba(0,0,0,0.8), inset 0px 0px 4px rgba(0,0,0,0.5);
+	color: #fff;
+	display: none;
+	height: 400px;
+	left: 0;
+	max-height: 400px;
+	overflow: auto;
+	padding: 15px 0;
+	position: fixed;
+	top: 28px;
+	width: 100%;
+	z-index: 100;
+}
+
+#cfdd_drafts_wrap .cfdd_content {
+	-webkit-column-count:2; /* Chrome, Safari, Opera */
+	-moz-column-count:2; /* Firefox */
+	column-count:2;
+	
+	-webkit-column-gap:30px; /* Chrome, Safari, Opera */
+	-moz-column-gap:30px; /* Firefox */
+	column-gap:30px;
+	
+	-webkit-column-rule:1px solid #777777; /* Chrome, Safari, Opera */
+	-moz-column-rule:1px solid #777777; /* Firefox */
+	column-rule:1px solid #777777;
+	
+	margin: 0 15px 0 15px;
+	padding-right: 15px
+}
+
+#cfdd_drafts_wrap .cfdd_content ul {
+	list-style:none;
+}
+
+#cfdd_drafts_wrap a,
+#cfdd_drafts_wrap a:visited {
+	color: #fff;
+}
+
+#cfdd_drafts_wrap .nodrafts {
+	cursor: default;
+}

--- a/drafts-dropdown.php
+++ b/drafts-dropdown.php
@@ -59,7 +59,7 @@ if ( !class_exists( 'WP_DraftsDropdown' ) ):
 			}
 		}
 		
-		function init() {
+		static function init() {
 			load_plugin_textdomain( 'drafts-dropdown' );
 			
 			wp_enqueue_script( 'drafts-dropdown', self::get_url() . 'js/drafts-dropdown.js', array( 'jquery' ) );

--- a/drafts-dropdown.php
+++ b/drafts-dropdown.php
@@ -2,9 +2,11 @@
 
 /*
 Plugin Name: Drafts Dropdown 
-Plugin URI: http://crowdfavorite.com/wordpress/plugins/drafts-dropdown/ 
+_Plugin URI: http://crowdfavorite.com/wordpress/plugins/drafts-dropdown/ 
 Description: Easy access to your WordPress drafts from the admin bar. Drafts are listed in a slide-down menu.
-Version: 2.0.2
+Version: 3.0.0
+Author: Paul Ellmaier
+Author URI: http://blog.anvor.at
 Author: Crowd Favorite
 Author URI: http://crowdfavorite.com
 */
@@ -13,6 +15,8 @@ Author URI: http://crowdfavorite.com
 //   Crowd Favorite, Ltd. - http://crowdfavorite.com
 //   Alex King - http://alexking.org
 // All rights reserved.
+// Copyright (c) 2014
+//	Paul Ellmaier - http://blog.anvor.at
 //
 // Released under the GPL license
 // http://www.opensource.org/licenses/gpl-license.php
@@ -25,207 +29,114 @@ Author URI: http://crowdfavorite.com
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
 // **********************************************************************
 
-// ini_set('display_errors', '1'); ini_set('error_reporting', E_ALL);
 
-load_plugin_textdomain('drafts-dropdown');
-
-function cfdd_get_drafts() {	
-	$args = array(
-	  'public' => true,
-	);
-	$post_types = get_post_types($args, 'names');
-	$query = array( 
-		'post_type' => $post_types, 
-		'post_status' => 'draft',
-		'posts_per_page' => 100,
-		'order' => 'DESC',
-		'orderby' => 'modified',
-	);
+//Exit if accessed directly
+if ( !defined( 'ABSPATH' ) ) 
+	exit;
 	
-	$drafts = new WP_Query($query);
-	return $drafts->posts;
-}
 
-function cfdd_drafts_content() {
-	$output = '';
-	$drafts = cfdd_get_drafts();
-	if (count($drafts)) {
-		$output .= '<ul id="cfdd_drafts">';
-		foreach ($drafts as $draft) {
-			$post_title = !empty($draft->post_title) ? esc_html($draft->post_title) : __('(untitled)', 'drafts-dropdown');
-			$output .= '<li><a href="'.esc_url(admin_url('post.php?action=edit&post='.$draft->ID)).'">'.$post_title.'</a></li>';
+if ( !class_exists( 'WP_DraftsDropdown' ) ):
+
+	class WP_DraftsDropdown
+	{
+	
+		public static function enable() {
+		
+			add_action('wp_ajax_cfdd_drafts_list', array( __CLASS__, 'ajax_drafts_list' ) );
+
+			add_action('admin_bar_menu', array( __CLASS__, 'admin_bar_menu_drafts' ), 45);
+
+			add_action('init', array( __CLASS__, 'init' ) );
 		}
-		$output .= '</ul>';
-	}
-	else {
-		$output .= '<p>'.__('(none)', 'drafts-dropdown').'</p>';
-	}
-	return $output;
-}
-
-function cfdd_ajax_drafts_list() {
-	if (!current_user_can('edit_posts')) {
-		return false;
-	}
-	$html = cfdd_drafts_content();
-	header('Content-type: application/json');
-	echo json_encode(compact('html'));
-	die();
-}
-add_action('wp_ajax_cfdd_drafts_list', 'cfdd_ajax_drafts_list');
-
-function cfdd_footer() {
-?>
-<style type="text/css">
-#cfdd_drafts_wrap {
-	background: #444;
-	border-top: 1px solid #999;
-	border-bottom: 5px solid #666;
-	-webkit-box-shadow: 0px 2px 2px rgba(0,0,0,0.8), inset 0px 0px 4px rgba(0,0,0,0.5);
-	box-shadow: 0px 2px 4px rgba(0,0,0,0.8), inset 0px 0px 4px rgba(0,0,0,0.5);
-	color: #fff;
-	display: none;
-	height: 400px;
-	left: 0;
-	max-height: 400px;
-	overflow: auto;
-	padding: 15px 0;
-	position: fixed;
-	top: 28px;
-	width: 100%;
-	z-index: 100;
-}
-#cfdd_drafts_wrap.loading {
-	background: #444 url(<?php echo admin_url('images/wpspin_dark.gif'); ?>) no-repeat center center;
-}
-#cfdd_drafts_wrap .cfdd_content {
-	visibility: hidden;
-}
-#cfdd_drafts_wrap a,
-#cfdd_drafts_wrap a:visited {
-	color: #fff;
-}
-#cfdd_drafts_wrap .cfdd_col {
-	border-right: 1px solid #777;
-	float: left;
-	margin: 0 0 0 15px;
-	padding-right: 15px;
-}
-#cfdd_drafts_wrap .cfdd_col ul {
-	font: 12px sans-serif;
-	line-height: 140%;
-	list-style: none;
-	margin: 0;
-	padding: 0;
-}
-#cfdd_drafts_wrap .cfdd_col ul li {
-	margin: 0 0 6px;
-}
-</style>
-<script type="text/javascript">
-jQuery(function($) {
-	$('#wp-admin-bar-cfdd_drafts_menu').click(function(e) {
-		e.preventDefault();
-// slide up
-		$wrap = $('#cfdd_drafts_wrap');
-		if ($wrap.size() && $wrap.is(':visible')) {
-			$wrap.slideUp(function() {
-				$(this).remove();
-			});
-			return;
+		
+		public static function admin_bar_menu_drafts($wp_admin_bar) {
+			if ( current_user_can( 'edit_posts' ) ) {
+				$wp_admin_bar->add_menu( array(
+					'id' => 'cfdd_drafts_menu',
+					'title' => __( 'Drafts' ),
+					'href' => admin_url( 'edit.php?post_status=draft&post_type=post' ),
+				) );
+			}
 		}
-// slide down
-		$('body').append('<div id="cfdd_drafts_wrap"><div class="cfdd_content"></div></div>');
-// show spinner
-		$wrap = $('#cfdd_drafts_wrap');
-		$wrap.css({'height': '400px'}).slideDown().addClass('loading');
-// load drafts
-		$.post(
-			'<?php echo admin_url('admin-ajax.php'); ?>',
-			{
-				action: 'cfdd_drafts_list'
-			},
-			function(response) {
-				$content = $wrap.find('.cfdd_content');
-				$content.html(response.html);
-// format cols
-				var drafts = $('#cfdd_drafts li');
-				var drafts_count = drafts.size();
-				var i = 0;
-				if (drafts_count <= 10) {
-// set to 2 columns
-					$content.append('<div class="cfdd_col" id="cfdd_col_1"><ul></ul></div><div class="cfdd_col" id="cfdd_col_2"><ul></ul></div><div class="cfdd_clear"></div>');
-					var col_count = Math.ceil(drafts_count / 2);
-					drafts.each(function() {
-						i < col_count ? target = '#cfdd_col_1 ul' : target = '#cfdd_col_2 ul';
-						$(this).appendTo(target);
-						i++;
-					});
-				}
-				else {
-// 3 columns
-					$content.append('<div class="cfdd_col" id="cfdd_col_1"><ul></ul></div><div class="cfdd_col" id="cfdd_col_2"><ul></ul></div><div class="cfdd_col" id="cfdd_col_3"><ul></ul></div><div class="cfdd_clear"></div>');
-					var col_count = Math.ceil(drafts_count / 3);
-					drafts.each(function() {
-						if (i < col_count) {
-							target = '#cfdd_col_1 ul';
-						}
-						else if (i >= col_count * 2) {
-							target = '#cfdd_col_3 ul';
-						}
-						else {
-							target = '#cfdd_col_2 ul';
-						}
-						$(this).appendTo(target);
-						i++;
-					});
-				}
-				$('#cfdd_drafts').remove();
-			// set size of cfdd_col
-				$('.cfdd_col').width(Math.floor($('body').width() - 120) / 3);
-				$('.cfdd_col:last').css('border-right', 0);
+		
+		function init() {
+			load_plugin_textdomain( 'drafts-dropdown' );
+			
+			wp_enqueue_script( 'drafts-dropdown', self::get_url() . 'js/drafts-dropdown.js', array( 'jquery' ) );
+			$i18n = array( 
+				'ajax_url'	=> admin_url( 'admin-ajax.php' ),
+				'no_drafts'	=> __('No drafts found', 'drafts-dropdown'),
+				'edit_url'	=> esc_url( admin_url( 'post.php?action=edit&post=' ) ),
+			);
+			wp_localize_script('drafts-dropdown', 'WP_DraftsDropdown', $i18n );
+			
+			wp_enqueue_style( 'drafts-dropdown', self::get_url() . 'css/drafts-dropdown.css' );
+		}
+		
+		public static function get_drafts() {	
+			$args = array(
+			  'public' => true,
+			);
+			$post_types = get_post_types( $args, 'names' );
+			$query = array( 
+				'post_type'			=> $post_types, 
+				'post_status'		=> 'draft',
+				'posts_per_page'	=> 100,
+				'order'				=> 'DESC',
+				'orderby'			=> 'modified',
+			);
+			
+			$drafts = new WP_Query( $query );
+			return $drafts->posts;
+		}
+		
+		public static function drafts_content() {
+			$output = array();
+			$drafts = self::get_drafts();
 
-				var height = 0;
-				$wrap.find('.cfdd_col').each(function() {
-					if ($(this).height() > height) {
-						height = $(this).height();
-					}
-				});
-				if (height < 400) {
-					$wrap.animate({ 'height': height + 'px' }, 'fast');
-				}
+			foreach ( $drafts as $draft ) {
+				$post_title = !empty( $draft->post_title ) ? esc_html( $draft->post_title ) : __( '(untitled)', 'drafts-dropdown' );
+				//$modified = DateTime::createFromFormat('Y-m-d H:i:s', $draft->post_modified)->getTimestamp();
+				$data = array( 
+								'title'		=> $post_title, 
+								/*'modified'	=> $modified,*/ //might consider sending more metadata in the future
+							);
+				$output[$draft->ID] = $data;
+			}
+			return json_encode($output);
+		}
+		
+		public static function ajax_drafts_list() {
+			if ( !current_user_can( 'edit_posts' ) ) {
+				return false;
+			}
+			$html = self::drafts_content();
+			header( 'Content-type: application/json' );
+			echo $html;
+			die();
+		}
+		
+		/**
+		 * Class should be able to be instantiated from a theme or plugin,
+		 * so we need to find out the url to the current folder in a
+		 * roundabout way.
+		 */
+		public static function get_url() {
+			// get and normalize framework dirname
+			$dirname = str_replace( '\\' ,'/', dirname( __FILE__ ) ); // standardize slash
+			$dirname = preg_replace( '|/+|', '/', $dirname );       // normalize duplicate slash
 
-// remove spinner, make visible
-				$wrap.removeClass('loading');
-				$content.hide().css({ 'visibility': 'visible' }).fadeIn();
-			},
-			'json'
-		);
-	});
-});
-</script>
-<?php
-}
-// attached in admin bar call below for back end
-// attached in init below for front end
+			// get and normalize WP content directory
+			$wp_content_dir = str_replace( '\\', '/', WP_CONTENT_DIR );  // standardize slash
 
-function cfdd_admin_bar_menu_drafts($wp_admin_bar) {
-	if (current_user_can('edit_posts')) {
-		$wp_admin_bar->add_menu(array(
-			'id' => 'cfdd_drafts_menu',
-			'title' => __('Drafts', 'drafts-dropdown'),
-			'href' => admin_url('edit.php?post_status=draft&post_type=post'),
-		));
+			// build relative url
+			$relative_url = str_replace( $wp_content_dir, "", $dirname );
+
+			// finally base url
+			return trailingslashit( content_url() . $relative_url );
+		}
 	}
-}
-add_action('admin_bar_menu', 'cfdd_admin_bar_menu_drafts', 45);
 
-function cfdd_init() {
-	if (current_user_can('edit_posts')) {
-		add_action('wp_footer', 'cfdd_footer');
-		add_action('admin_footer', 'cfdd_footer');
-	}
-}
-add_action('init', 'cfdd_init');
+endif;
 
-//a:22:{s:11:"plugin_name";s:15:"Drafts Dropdown";s:10:"plugin_uri";s:38:"http://alexking.org/projects/wordpress";s:18:"plugin_description";s:112:"Easy access to your WordPress drafts from within the web admin interface. Drafts are listed in a drop-down menu.";s:14:"plugin_version";s:3:"1.0";s:6:"prefix";s:4:"cfdd";s:12:"localization";s:14:"draft-dropdown";s:14:"settings_title";N;s:13:"settings_link";N;s:4:"init";b:0;s:7:"install";b:0;s:9:"post_edit";b:0;s:12:"comment_edit";b:0;s:6:"jquery";b:0;s:6:"wp_css";b:0;s:5:"wp_js";b:0;s:9:"admin_css";b:0;s:8:"admin_js";s:1:"1";s:15:"request_handler";b:0;s:6:"snoopy";b:0;s:11:"setting_cat";b:0;s:14:"setting_author";b:0;s:11:"custom_urls";b:0;}
+WP_DraftsDropdown::enable();

--- a/js/drafts-dropdown.js
+++ b/js/drafts-dropdown.js
@@ -1,0 +1,67 @@
+jQuery( document ).ready( function($) {
+	$( 'body' ).append( '<div id="cfdd_drafts_wrap"><div class="cfdd_content"></div></div>' );
+} );
+	
+jQuery( document ).on( 'click', '#wp-admin-bar-cfdd_drafts_menu', function(e) {
+	e.preventDefault();
+	var $ = jQuery;
+	
+	// slide up
+	$wrap = $( '#cfdd_drafts_wrap' );
+	if ( $wrap.size() && $wrap.is( ':visible' ) ) {
+		$wrap.slideUp( function() {
+			$( this ).find( '.cfdd_content ul' ).remove();
+		} );
+		return;
+	}
+	
+
+	$wrap = $( '#cfdd_drafts_wrap' );
+	
+	// show spinner
+	$menuitem = $( '#wp-admin-bar-cfdd_drafts_menu' );
+	$menuitem.addClass('loading');
+	
+	// load drafts
+	$.post(
+		WP_DraftsDropdown.ajax_url,
+		{
+			action: 'cfdd_drafts_list',
+		},
+		function ( response ) {
+		
+			$content = $wrap.find( '.cfdd_content' );
+			var $length = Object.keys( response ).length;
+			if ( 0 == $length ) {
+				$content.append( '<ul class="nodrafts"><li>' + WP_DraftsDropdown.no_drafts + '</li></ul>' );
+			} else {
+				var $list = $content.append( '<ul></ul>' ).find( 'ul' );
+				for ( var draft in response ) {
+					$list.append( '<li><a href="' + WP_DraftsDropdown.edit_url + draft + '">' + response[draft].title + '</a></li>' );
+				}
+			}
+			
+			$list = $content.find( 'ul' );
+			
+			//we need this to get the actual height of the list
+			var pos = $wrap.css( 'position' );
+			$wrap.css( {
+				position:   'absolute', 
+				visibility: 'hidden',
+				display:    'block'
+			} );
+
+			var actualHeight = ( $list.height() <= 400 ) ? $list.height() : 400;
+
+			$wrap.css( {
+				position:   pos, 
+				visibility: 'visible',
+				height: 0,
+			} );
+							
+			$wrap.hide().height( actualHeight ).slideDown();
+			$menuitem.removeClass('loading');
+		},
+		'json'
+	);
+} );


### PR DESCRIPTION
I did a complete code overhaul on the entire plugin. I wrapped the main code into a class with static functions to keep the global namespace clean.

I also did an AJAX overhaul. Now the plugin only sends metadata and everything html-related is done on the clientside

I fixed slideDown followed by slideUp. This bugged me the most, so I redid how the dropdown is built and it's height is being calculated. So it only needs to slide down once it's done.

I also redesigned how the columns are being handled. CSS 3 has some neat properties for that, and now everyone can easily choose how many columns the want

And lastly I moved inline script and style to seperate file so they can be cached by plugins like W3 Total Cache

I've tested the code down to WP 3.8 ( because everything older than that should be updated anyways. ) and added on to the README.txt accordingly
